### PR TITLE
Add sleep to permit Fabric to start

### DIFF
--- a/packages/getting-started/scripts/start-hyperledger.sh
+++ b/packages/getting-started/scripts/start-hyperledger.sh
@@ -13,6 +13,9 @@ docker-compose -f hlfv1_alpha-docker-compose.yml down
 docker rm $(docker ps -aq) ||
 docker-compose -f hlfv1_alpha-docker-compose.yml up -d
 
+# wait for Hyperledger Fabric to start 
+sleep 10
+
 node create-channel.js
 node join-channel.js
 cd ../..


### PR DESCRIPTION
Added a sleep to permit Fabric to start. 

Similar to the sleep that had to added to the v0.6 based scripts. 