### PR TITLE
Correct the getting started quickstart URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The repository contains sample applications written against the [Fabric Composer](https://github.com/fabric-composer/fabric-composer) [client and admin APIs](https://fabric-composer.github.io/jsdoc/index.html).
 
-Currently this contains the code and scripts for the ['Getting Started'](https://fabric-composer.github.io/start/quickstart.html) tutorial.
+Currently this contains the code and scripts for the ['Getting Started'](https://fabric-composer.github.io/installing/quickstart.html) tutorial.
 
 We welcome Pull Requests for new applications - please see the [contributing notes](https://github.com/fabric-composer/fabric-composer/blob/master/CONTRIBUTING.md).
 


### PR DESCRIPTION
change 'start' with 'installing' - (subdirectory name in path)